### PR TITLE
set tess version to 62 to test new constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hammerjs": "^2.0.8",
     "jszip": "^3.1.3",
     "rxjs": "^5.0.1",
-    "syd-tessellation": "0.0.61",
+    "syd-tessellation": "0.0.62",
     "syd-visualization": "0.0.45",
     "three": "0.83.0",
     "ts-helpers": "^1.1.1",


### PR DESCRIPTION
updating sydtest to use new automated constraint solver, specifically testing constraints on transitions 